### PR TITLE
Fixed bug when -std=c++11 is enabled

### DIFF
--- a/src/NumbTh.cpp
+++ b/src/NumbTh.cpp
@@ -1392,7 +1392,7 @@ void rem(zz_pX& r, const zz_pX& a, const zz_pXModulus1& ff)
 // Debug printing routines for vectors, ZZX'es, print only a few entries
 
 template<class T> ostream& printVec(ostream& s, const Vec<T>& v,
-				    long nCoeffs=40)
+				    long nCoeffs)
 {
   long d = v.length();
   if (d<nCoeffs) return s << v; // just print the whole thing

--- a/src/NumbTh.h
+++ b/src/NumbTh.h
@@ -121,7 +121,7 @@ bool doArgProcessing(T *value, const char *s)
 {
   string ss(s);
   stringstream sss(ss);
-  return sss >> *value;
+  return bool(sss >> *value);
 }
 
 bool doArgProcessing(string *value, const char *s);


### PR DESCRIPTION
When the C++11 flag is enabled, then you get a "redefinition of default argument" error, since you gave a default parameter in the header and the corresponding file. Such parameters should only be given in the header file. After this fix everything compiles fine on OS X 10.10.3 with NTL 9.0.2.

However, when running make check you further need to add a cast to bool to the return value in NumbTh.h in the doArgProcessing function.

