### PR TITLE
[FHEContext] Fix the divide by zero error

### DIFF
--- a/src/FHEContext.cpp
+++ b/src/FHEContext.cpp
@@ -105,8 +105,9 @@ long FindM(long k, long L, long c, long p, long d, long s, long chosen_m, bool v
     };
     for (i=0; i<sizeof(ms)/sizeof(long[4]); i++) { 
       if (ms[i][0] < N || GCD(p, ms[i][1]) != 1) continue;
-      long ordP = multOrd(p, ms[i][1]);
-      long nSlots = ms[i][0]/ordP;
+      long ordP = multOrd(p, ms[i][1]); // The function multOrd returns zero
+      assert(ordP != 0); // Sanity-check
+      long nSlots = ms[i][0]/ordP; // The divisor cannot be zero
       if (d != 0 && ordP % d != 0) continue;
       if (nSlots < s) continue;
 


### PR DESCRIPTION
🐛 label: [CWE-369](https://cwe.mitre.org/data/definitions/369.html)

Greetings,

In `long FindM(long k, long L, long c, long p, long d, long s, long chosen_m, bool verbose)`, a call to `multOrd` on line 108 of [FHEContext.cpp](https://github.com/shaih/HElib/blob/master/src/FHEContext.cpp) may assign a value of zero to a divisor of type long. A divide by zero creates an error. It is good practice to validate the value used as a denominator to ensure that a divide by zero error will not cause unexpected results.

Signed-off-by: Bryon Gloden, CISSP® <cissp@bryongloden.com>