### PR TITLE
Fix typo in Makefile (Text_tableLookup_x -> Test_tableLookup_x)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -49,12 +49,12 @@ SRC = KeySwitching.cpp EncryptedArray.cpp FHE.cpp Ctxt.cpp CModulus.cpp FHEConte
 
 OBJ = NumbTh.o timing.o bluestein.o PAlgebra.o  CModulus.o FHEContext.o IndexSet.o DoubleCRT.o FHE.o KeySwitching.o Ctxt.o EncryptedArray.o replicate.o hypercube.o matching.o powerful.o BenesNetwork.o permutations.o PermNetwork.o OptimizePermutations.o eqtesting.o polyEval.o extractDigits.o EvalMap.o recryption.o debugging.o matmul.o matmul1D.o blockMatmul.o blockMatmul1D.o intraSlot.o binaryArith.o binaryCompare.o tableLookup.o
 
-TESTPROGS = Test_General_x Test_PAlgebra_x Test_IO_x Test_Replicate_x Test_LinPoly_x Test_matmul_x Test_matmul1D_x Test_Powerful_x Test_Permutations_x Test_Timing_x Test_PolyEval_x Test_extractDigits_x Test_EvalMap_x Test_bootstrapping_x Test_PtrVector_x Test_intraSlot_x Test_binaryArith_x Test_binaryCompare_x Text_tableLookup_x
+TESTPROGS = Test_General_x Test_PAlgebra_x Test_IO_x Test_Replicate_x Test_LinPoly_x Test_matmul_x Test_matmul1D_x Test_Powerful_x Test_Permutations_x Test_Timing_x Test_PolyEval_x Test_extractDigits_x Test_EvalMap_x Test_bootstrapping_x Test_PtrVector_x Test_intraSlot_x Test_binaryArith_x Test_binaryCompare_x Test_tableLookup_x
 
 
 all: fhe.a
 
-check: Test_General_x Test_matmul_x Test_matmul1D_x Test_LinPoly_x Test_Permutations_x Test_PolyEval_x Test_Replicate_x Test_EvalMap_x Test_extractDigits_x Test_bootstrapping_x Test_binaryArith_x Test_binaryCompare_x Text_tableLookup_x
+check: Test_General_x Test_matmul_x Test_matmul1D_x Test_LinPoly_x Test_Permutations_x Test_PolyEval_x Test_Replicate_x Test_EvalMap_x Test_extractDigits_x Test_bootstrapping_x Test_binaryArith_x Test_binaryCompare_x Test_tableLookup_x
 	./Test_General_x R=1 k=10 p=2 r=2 noPrint=1
 	./Test_General_x R=1 k=10 p=2 d=2 noPrint=1
 	./Test_General_x R=2 k=10 p=7 r=2 noPrint=1
@@ -70,7 +70,7 @@ check: Test_General_x Test_matmul_x Test_matmul1D_x Test_LinPoly_x Test_Permutat
 	./Test_bootstrapping_x p=7 noPrint=1
 	./Test_binaryArith_x
 	./Test_binaryCompare_x
-	./Text_tableLookup_x
+	./Test_tableLookup_x
 
 test: $(TESTPROGS)
 


### PR DESCRIPTION
Hi.

I'm a newbie in HElib and installed it today. When I run `make check`, it failed.
This PR will fix it.