### PR TITLE
main() without int causes compile issue on clang

### DIFF
--- a/src/Test_PtrVector.cpp
+++ b/src/Test_PtrVector.cpp
@@ -114,7 +114,7 @@ void test5(const MyPtrMat& mat, const T& array)
 }
 
 
-main()
+int main()
 {
   const int vLength=6;
 


### PR DESCRIPTION
Get this error when running ```make test``` with OSX High Sierra 10.13.3, with gcc/++-7.
```
g++ -g -O2 -std=c++11 -pthread -DFHE_THREADS -DFHE_BOOT_THREADS -fmax-errors=2 -o Test_PtrVector_x Test_PtrVector.cpp fhe.a -L/usr/local/lib -lntl -lgmp -lm
clang: warning: argument unused during compilation: '-fmax-errors=2' [-Wunused-command-line-argument]
Test_PtrVector.cpp:117:1: error: C++ requires a type specifier for all declarations
main()
^
1 error generated.
```
Changed main() -> int main() to fix compile issues on OSX