### PR TITLE
Update Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ check:
 	$(MAKE) check_binaryArith
 	$(MAKE) check_binaryCompare
 	$(MAKE) check_tableLookup
-	$(MAKE) check_Test_Bin_IO_x
+	$(MAKE) check_Bin_IO_x
 
 check_General: Test_General_x 
 	./Test_General_x R=1 k=10 p=2 r=2 noPrint=1


### PR DESCRIPTION
To fix the error.

make[1]: Entering directory `HELIB/HElib-master/src'
make[1]: *** No rule to make target `check_Test_Bin_IO_x'.  Stop.
make[1]: Leaving directory `/HELIB/HElib-master/src'
make: *** [check] Error 2
